### PR TITLE
Removed a safety check which itself is never correct

### DIFF
--- a/raftstore/peer_event_loop.go
+++ b/raftstore/peer_event_loop.go
@@ -484,15 +484,6 @@ func (pr *peerReplica) doCheckCompact() {
 				return
 			}
 
-			if idx > compactIdx {
-				logger.Fatalf("shard %d adjust compact idx %d failed, invalid adjust idx %d",
-					pr.shardID,
-					compactIdx,
-					idx,
-					err)
-				return
-			}
-
 			logger.Infof("shard %d compact idx %d updated to %d",
 				pr.shardID,
 				compactIdx,


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #231 

**What this PR does / why we need it:**

When calculating raft log compaction index, we previously read the applied index value maintained by the apply worker thread from the event worker thread. It then checks AOE's segmentID value from the event worker thread and crash as soon as the applied index is less than the segmentID value. 

This is incorrect, the segmentID value read after the applied index value can of course be larger as the apply worker thread can be busy applying new committed raft entries.   


**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
