### PR TITLE
Fix #365 removed limitNumOfEntriesToApply()

### DIFF
--- a/raftstore/replica_event_raft_ready.go
+++ b/raftstore/replica_event_raft_ready.go
@@ -28,9 +28,6 @@ import (
 )
 
 var (
-	// testMaxOnceCommitEntryCount defines how many committed entries can be
-	// applied each time. 0 means unlimited
-	testMaxOnceCommitEntryCount = 0
 	// ErrUnknownReplica indicates that the replica is unknown.
 	ErrUnknownReplica = errors.New("unknown replica")
 )
@@ -48,7 +45,6 @@ func (pr *replica) handleReady(wc *logdb.WorkerContext) error {
 		return err
 	}
 	pr.sendRaftMessages(rd)
-	rd = pr.limitNumOfEntriesToApply(rd)
 	if err := pr.applyCommittedEntries(rd); err != nil {
 		return err
 	}
@@ -121,14 +117,6 @@ func (pr *replica) handleAppendEntries(rd raft.Ready,
 		return err
 	}
 	return nil
-}
-
-func (pr *replica) limitNumOfEntriesToApply(rd raft.Ready) raft.Ready {
-	if testMaxOnceCommitEntryCount > 0 &&
-		testMaxOnceCommitEntryCount < len(rd.CommittedEntries) {
-		rd.CommittedEntries = rd.CommittedEntries[:testMaxOnceCommitEntryCount]
-	}
-	return rd
 }
 
 func (pr *replica) applyCommittedEntries(rd raft.Ready) error {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #365 

**What this PR does / why we need it:**

It seems to me that limitNumOfEntriesToApply() is used to stop certain entries from being applied to control ReadIndex progress in tests. This is way too invasive. There are much better approaches that can achieve the same in tests without being so invasive - 

* control what entries can be replicated. entries can't be applied if they can't be replicated.
* pause in the Write() method in data storage to prevent further entries to be applied. 


**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
