### PR TITLE
Fix skip raft campaign in event loop

### DIFF
--- a/raftstore/replica.go
+++ b/raftstore/replica.go
@@ -362,16 +362,8 @@ func (pr *replica) notifyWorker() {
 	pr.store.workerPool.notify(pr.shardID)
 }
 
-func (pr *replica) maybeCampaign() (bool, error) {
-	if len(pr.getShard().Replicas) <= 1 {
-		// The replica campaigned when it was created, no need to do it again.
-		return false, nil
-	}
-	if err := pr.rn.Campaign(); err != nil {
-		return false, err
-	}
-
-	return true, nil
+func (pr *replica) doCampaign() error {
+	return pr.rn.Campaign()
 }
 
 func (pr *replica) onReq(req rpc.Request, cb func(rpc.ResponseBatch)) error {

--- a/raftstore/replica_event_loop.go
+++ b/raftstore/replica_event_loop.go
@@ -201,7 +201,7 @@ func (pr *replica) handleAction(items []interface{}) bool {
 			pr.doSplit(act)
 		case campaignAction:
 			if err := pr.doCampaign(); err != nil {
-				pr.logger.Fatal("tailed to do campaign",
+				pr.logger.Fatal("failed to do campaign",
 					zap.Error(err))
 			}
 		case heartbeatAction:

--- a/raftstore/replica_event_loop.go
+++ b/raftstore/replica_event_loop.go
@@ -200,8 +200,8 @@ func (pr *replica) handleAction(items []interface{}) bool {
 		case splitAction:
 			pr.doSplit(act)
 		case campaignAction:
-			if _, err := pr.maybeCampaign(); err != nil {
-				pr.logger.Fatal("tail to campaign in raft",
+			if err := pr.doCampaign(); err != nil {
+				pr.logger.Fatal("tailed to do campaign",
 					zap.Error(err))
 			}
 		case heartbeatAction:


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #379 

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

In the event loop thread of the raft, the campaign is skipped when there is only one replica of the raft-group, resulting in a timeout election time before the leader is elected
