### PR TITLE
Handle unprocessed worker request on exit

### DIFF
--- a/raftstore/replica_snapshot_test.go
+++ b/raftstore/replica_snapshot_test.go
@@ -146,7 +146,7 @@ func TestReplicaSnapshotCanBeApplied(t *testing.T) {
 
 		_, err = r.sm.dataStorage.GetInitialStates()
 		assert.NoError(t, err)
-		persistentLogIndex, err := r.sm.dataStorage.GetPersistentLogIndex(shard.ID)
+		persistentLogIndex, err = r.sm.dataStorage.GetPersistentLogIndex(shard.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), persistentLogIndex)
 

--- a/raftstore/worker_pool.go
+++ b/raftstore/worker_pool.go
@@ -78,6 +78,11 @@ func (w *replicaWorker) workerMain() {
 	for {
 		select {
 		case <-w.stopper.ShouldStop():
+			select {
+			case <-w.requestC:
+				w.completed()
+			default:
+			}
 			w.wc.Close()
 			w.logger.Debug("worker pool worker stopped",
 				zap.Uint64("worker-id", w.workerID))


### PR DESCRIPTION
This change makes tests easier to test the exit state of the pool.

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #539 

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
