### PR TITLE
Changed hlc.Clock interface

### DIFF
--- a/util/hlc/hlc_test.go
+++ b/util/hlc/hlc_test.go
@@ -55,7 +55,7 @@ func TestNewUnixNanoHLCClock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c := NewUnixNanoHLCClock(ctx, 500*time.Millisecond)
-	result := c.Now()
+	result, _ := c.Now()
 	assert.True(t, v < result.PhysicalTime)
 }
 
@@ -99,12 +99,16 @@ func TestNow(t *testing.T) {
 	c := NewHLCClock(pc, time.Second)
 
 	c.mu.ts = Timestamp{PhysicalTime: 100, LogicalTime: 10}
-	result := c.Now()
+	result, _ := c.Now()
 	assert.Equal(t, Timestamp{PhysicalTime: 200}, result)
 
 	c.mu.ts = Timestamp{PhysicalTime: 300, LogicalTime: 10}
-	result = c.Now()
+	result, _ = c.Now()
 	assert.Equal(t, Timestamp{PhysicalTime: 300, LogicalTime: 11}, result)
+
+	result, upperBound := c.Now()
+	assert.Equal(t, result.PhysicalTime+int64(c.MaxOffset()), upperBound.PhysicalTime)
+	assert.Equal(t, uint32(0), upperBound.LogicalTime)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

- [x] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #

**What this PR does / why we need it:**

Removed hlc.Clock.NowUpperBound(), hlc.Clock.Now() returns both the current timestamp and the upper bound. 

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
